### PR TITLE
Update secret data size limit to 10KB

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,8 +116,8 @@ func createMap(baseDir string) {
 			log.Printf("Error %v\n", err)
 			return err
 		}
-		// Max AWS secret size is 4 KB
-		if !info.IsDir() && info.Size() <= 4096 {
+		// Max AWS secret size is 10 KB
+		if !info.IsDir() && info.Size() <= 10000 {
 			go load(path, info.Name())
 			wg.Add(1)
 		}


### PR DESCRIPTION
Secret data size limit 4KB -> 10KB

https://aws.amazon.com/about-aws/whats-new/2019/10/aws-secrets-manager-supports-increased-secret-size-api-request-rate/